### PR TITLE
Fix chart normalization bug

### DIFF
--- a/app.js
+++ b/app.js
@@ -140,7 +140,9 @@ async function loadHistory(){
     options:{
       responsive:true,
       maintainAspectRatio:false,  // parent precisa de altura definida (ver CSS abaixo)
-      normalized:true,            // ignora outliers/NaN em cálculos internos
+      // Normalizar os dados causava problemas quando todos os valores eram 0 ou nulos,
+      // levando o gráfico a crescer indefinidamente. Mantemos os valores originais.
+      normalized:false,
       animation:false,
       plugins:{ legend:{display:false}, tooltip:{enabled:true} },
       scales:{


### PR DESCRIPTION
## Summary
- Disable Chart.js data normalization to prevent canvas height from expanding infinitely when temperature values are zero or missing

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_689cac6d5634832ea6518c440cc8584f