### PR TITLE
Fix climate endpoint and load data for Clima page

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,7 +9,8 @@ const PUSH_MS = 120000;
 const CSSVARS = getComputedStyle(document.documentElement);
 const ACCENT = (CSSVARS.getPropertyValue("--accent") || "#3b82f6").trim();
 const ACCENT2 = (CSSVARS.getPropertyValue("--accent-2") || "#94a3b8").trim();
-const CLIMATE_URL = `${API_BASE}/#/clima`;
+// Endpoint de clima mensal da API
+const CLIMATE_URL = `${API_BASE}/climate/monthly`;
 const VIEWS = document.querySelectorAll('[data-view]');
 const LINKS = document.querySelectorAll('[data-viewlink]');
 let liveTimer = null;
@@ -609,7 +610,8 @@ async function loadHistory() {
   });
 }
 
-async function loadClimate() {
+// Carrega dados climáticos mensais e preenche a tabela
+async function loadClimateMonthly() {
   const r = await fetch(CLIMATE_URL, { cache: 'no-store' });
   if (!r.ok) throw new Error(`climate ${r.status}`);
   const j = await r.json();

--- a/server/api_meteo-py
+++ b/server/api_meteo-py
@@ -427,7 +427,8 @@ def history(hours: int = Query(24, ge=1, le=168)):
     conn.close()
     return rows
 
-@app.get("/#/clima")
+# Endpoint de clima mensal (sem fragmentos de URL)
+@app.get("/climate/monthly")
 def climate_monthly(station: str = "meteomg"):
     conn = mysql.connector.connect(**DB_CONFIG)
     cur = conn.cursor(dictionary=True)


### PR DESCRIPTION
## Summary
- serve monthly climate data at `/climate/monthly` instead of hash fragment path
- load climate table from new endpoint on the Clima view

## Testing
- `python3 -m py_compile server/api_meteo-py && echo OK`
- `node --check app.js && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_68a6154f38d0832ebcd169e5a260def3