### PR TITLE
Remove unused CSS classes

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -115,13 +115,6 @@ body {
     line-height: 1;
 }
 
-.now-ext {
-    position: absolute;
-    right: -0.5ch;
-    font-weight: 800;
-    font-size: clamp(14px, 2.1vw, 22px);
-    line-height: 1;
-}
 
 .t-ext {
     position: absolute;
@@ -411,31 +404,6 @@ body {
     animation: pulseColor .35s ease-out;
 }
 
-/* cabeçalho com título à esquerda e menu à direita */
-.site-head {
-    display: flex;
-    align-items: flex-end;
-    justify-content: space-between;
-    gap: var(--gap);
-    margin-top: .4rem;
-    /* como tinhas */
-}
-
-.brand h1 {
-    margin: 0;
-    font-weight: 900;
-    letter-spacing: .3px;
-}
-
-.brand a {
-    color: inherit;
-    text-decoration: none;
-}
-
-.brand #nowDate {
-    margin: .25rem 0 0;
-    color: var(--muted);
-}
 
 .main-nav {
     display: flex;
@@ -464,35 +432,6 @@ body {
     color: #fff;
 }
 
-/* Header: título à esquerda, menu à direita */
-.site-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 16px 24px;
-    position: sticky;
-    top: 0;
-    z-index: 10;
-}
-
-.site-header .brand {
-    font-weight: 800;
-    font-size: 1.6rem;
-    text-decoration: none;
-    color: inherit;
-}
-
-.main-nav a {
-    text-decoration: none;
-    margin-left: 16px;
-    font-weight: 600;
-    opacity: .8;
-}
-
-.main-nav a.active {
-    opacity: 1;
-    text-decoration: underline;
-}
 
 /* Vistas */
 [hidden] {
@@ -559,10 +498,6 @@ body {
     font-weight: 700;
 }
 
-/* se quiseres espaçar o título do menu sem gap(): */
-.site-header .main-nav a+a {
-    margin-left: 20px;
-}
 
 
 
@@ -714,15 +649,6 @@ body {
 
     .now-metrics span {
         min-width: 96px;
-    }
-
-    .site-head {
-        flex-wrap: wrap;
-        align-items: center;
-    }
-
-    .brand {
-        flex: 1 1 100%;
     }
 
     .main-nav {


### PR DESCRIPTION
## Summary
- drop orphaned now-ext style
- clean old header classes (site-head, site-header, brand)

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a61badd290832e9f02bd1f2c304579